### PR TITLE
refactor(config): move extraction logic to config.ts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,8 +2,11 @@ export interface Config {
   powerAssert: boolean;
 }
 
-const defaultConfig: Config = {
+export const defaultConfig: Config = {
   powerAssert: true,
 };
 
-export default defaultConfig;
+export const extractConfigFromState = (state: any): Config => ({
+  ...defaultConfig,
+  ...state.opts,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { NodePath } from 'babel-traverse';
 import * as BabelTypes from 'babel-types';
 
 import assertifyStatement from './assertify-statement';
-import defaultConfig, { Config } from './config';
+import { extractConfigFromState } from './config';
 
 const assertionBlockLabels = ['expect', 'then'];
 
@@ -18,7 +18,8 @@ const plugin = (babel: { types: typeof BabelTypes }): PluginObj => {
   return {
     visitor: {
       LabeledStatement(path, state) {
-        const config = { ...defaultConfig, ...(state.opts as Config) };
+        const config = extractConfigFromState(state);
+
         if (assertionBlockLabels.includes(path.node.label.name)) {
           const bodyPath = path.get('body') as NodePath<BabelTypes.Statement>;
           switch (bodyPath.type) {


### PR DESCRIPTION
prevent potential future code duplication by moving config extraction that is required at that beginning of a visitor function to ´config.ts`