### PR TITLE
fix(assertions): support non-standard JSX syntax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ const assertionBlockLabels = ['expect', 'then'];
 const plugin = (babel: { types: typeof BabelTypes }): PluginObj => {
   const assertify = assertifyStatement(babel.types);
   const espowerVisitor = createEspowerVisitor(babel, {
-    embedAst: false,
+    embedAst: true,
     patterns: ['assert(value)'],
   });
 
@@ -36,9 +36,6 @@ const plugin = (babel: { types: typeof BabelTypes }): PluginObj => {
             // Now let espower generate nice power assertions for this labeled statement
             espowerVisitor.visitor.Program(path, state);
           }
-
-          // We're done here, all processing is shallow
-          path.skip();
         }
       },
     },

--- a/test/__snapshots__/power-assert.test.ts.snap
+++ b/test/__snapshots__/power-assert.test.ts.snap
@@ -44,3 +44,20 @@ exports[`still works if babel-plugin-espower is used for other assertions in the
          -1     
   "
 `;
+
+exports[`supports non-standard JSX syntax 1`] = `
+"  # unknown:2
+  
+  assert(<div></div>.prop === 'expected')
+                     |    |              
+                     |    false          
+                     \\"div\\"               
+  
+  --- [string] 'expected'
+  +++ [string] <div></div>.prop
+  @@ -1,8 +1,3 @@
+  -expected
+  +div
+  
+  "
+`;

--- a/test/power-assert.test.ts
+++ b/test/power-assert.test.ts
@@ -75,3 +75,27 @@ test('still works if babel-plugin-espower is used for other assertions in the fi
     expect(err.message).toMatchSnapshot();
   }
 });
+
+test('supports non-standard JSX syntax', () => {
+  const createElement = jest
+    .fn()
+    .mockImplementationOnce(tagName => ({ prop: tagName }));
+
+  const { code } = transform(
+    `import assert from 'power-assert';
+    expect: (<div></div>).prop === 'expected';`,
+    {
+      plugins: [plugin],
+      presets: ['env', 'react'],
+    },
+  );
+
+  expect.assertions(1);
+  try {
+    new Function('require', 'React', code as string)(require, {
+      createElement,
+    });
+  } catch (err) {
+    expect(err.message).toMatchSnapshot();
+  }
+});


### PR DESCRIPTION
Previously, JSX occurring in an assertion block would not be transpiled at all, resulting in a syntax error when running the tests.

Now, JSX is transpiled (given that the user sets up his babel config correctly) and power assertions also show the syntax in their error messages.