### PR TITLE
fix(auto-import): avoid unnecessary duplicate imports

### DIFF
--- a/src/assertify-statement.ts
+++ b/src/assertify-statement.ts
@@ -29,7 +29,7 @@ export default (
     // register added import with scope so it is found for the next assertion
     // for some reason, this needs to happen after we have referenced the import
     // with our call expression, otherwise the import will be removed
-    (scope as any).crawl();
+    (scope.getProgramParent() as any).crawl();
 
     if (config.powerAssert) {
       // Now let espower generate nice power assertions for this assertion

--- a/test/__snapshots__/auto-import.test.ts.snap
+++ b/test/__snapshots__/auto-import.test.ts.snap
@@ -46,6 +46,16 @@ expect: _assert(1 === 1);
 expect: _assert(2 === 2);"
 `;
 
+exports[`reuses the same import for multiple assertions in nested scopes 1`] = `
+"import _assert from \\"power-assert\\";
+
+(() => {
+  expect: _assert(1 === 1);
+
+  expect: _assert(2 === 2);
+})();"
+`;
+
 exports[`uses an existing default import 1`] = `
 "import fancyAssert from 'power-assert';
 

--- a/test/auto-import.test.ts
+++ b/test/auto-import.test.ts
@@ -69,6 +69,19 @@ test('reuses the same import for multiple assertions', () => {
   expect(code).toMatchSnapshot();
 });
 
+test('reuses the same import for multiple assertions in nested scopes', () => {
+  const { code } = transform(
+    `(() => {
+      expect: 1 === 1;
+      expect: 2 === 2;
+    })()`,
+    {
+      plugins: [[plugin, { powerAssert: false } as Config]],
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
 test('does not break preset-env module transform and generates code runnable in node', () => {
   const { code } = transform(`expect: 1 === 2;`, {
     plugins: [[plugin, { powerAssert: false } as Config]],


### PR DESCRIPTION
If the assertion blocks are not in the top-level scope (which will usually be the case), the plugin currently does not reuse assert function imports.
This PR fixes that and adds a regression test.