### PR TITLE
feat(assert-function-name/auto-import): gracefully handle conflicts b…

### DIFF
--- a/src/generate-assert-identifier.ts
+++ b/src/generate-assert-identifier.ts
@@ -37,6 +37,11 @@ const addImport = (
   source: string,
   name: string,
 ) => {
+  if (name) {
+    // clear possible binding conflicts
+    scope.rename(name);
+  }
+
   const program = scope.getProgramParent().path;
 
   // generate default or specified import from source

--- a/test/__snapshots__/assert-function-name.test.ts.snap
+++ b/test/__snapshots__/assert-function-name.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not rename non-conflicting bindings of the same name 1`] = `
+"import check from \\"power-assert\\";
+{
+  let check;
+}
+
+expect: check(1 === 1);"
+`;
+
 exports[`generates import with specified name when autoImport is set 1`] = `
 "import check from \\"power-assert\\";
 
@@ -7,3 +16,11 @@ expect: check(1 === 1);"
 `;
 
 exports[`generates specified assert function 1`] = `"expect: check(1 === 1);"`;
+
+exports[`renames conflicting bindings when autoImporting 1`] = `
+"import check from \\"power-assert\\";
+
+let _check;
+
+expect: check(1 === 1);"
+`;

--- a/test/assert-function-name.test.ts
+++ b/test/assert-function-name.test.ts
@@ -27,3 +27,45 @@ test('generates import with specified name when autoImport is set', () => {
   });
   expect(code).toMatchSnapshot();
 });
+
+test('renames conflicting bindings when autoImporting', () => {
+  const { code } = transform(
+    `let check;
+    expect: 1 === 1;`,
+    {
+      plugins: [
+        [
+          plugin,
+          {
+            ...minimalConfig,
+            assertFunctionName: 'check',
+            autoImport: true,
+          } as Config,
+        ],
+      ],
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+test('does not rename non-conflicting bindings of the same name', () => {
+  const { code } = transform(
+    `{
+      let check;
+    }
+    expect: 1 === 1;`,
+    {
+      plugins: [
+        [
+          plugin,
+          {
+            ...minimalConfig,
+            assertFunctionName: 'check',
+            autoImport: true,
+          } as Config,
+        ],
+      ],
+    },
+  );
+  expect(code).toMatchSnapshot();
+});


### PR DESCRIPTION
…y renaming existing bindings

This is not really a must have, because `assertFunctionName` is primarily useful for codemods and with this change it is still necessary to manually ensure there are no conflicts or we will have an ugly identifier in the codemod output.

However, this rename is so simple that the plugin might as well behave and not break *everything* if there's a conflict.